### PR TITLE
Fixed incorrect way to retrieve string from StringFormat<32> result

### DIFF
--- a/src/db/plugins/upnp/ContentDirectoryService.cxx
+++ b/src/db/plugins/upnp/ContentDirectoryService.cxx
@@ -93,8 +93,9 @@ ContentDirectoryService::readDirSlice(UpnpClient_Handle hdl,
 		{"BrowseFlag", "BrowseDirectChildren"},
 		{"Filter", "*"},
 		{"SortCriteria", ""},
-		{"StartingIndex", &(StringFormat<32>("%u", offset)[0])},
-		{"RequestedCount", &(StringFormat<32>("%u", count)[0])}};
+		{"StartingIndex", StringFormat<32>("%u", offset).c_str()},
+		{"RequestedCount", StringFormat<32>("%u", count).c_str()}
+        };
 	std::vector<std::pair<std::string, std::string>> responseData;
 	int errcode;
 	std::string errdesc;


### PR DESCRIPTION
I believe that the code which generated a warning was actually incorrect given how the stringformat utility was implemented.